### PR TITLE
Update codebase for ghc-7.10.1 compatibility

### DIFF
--- a/haskell-neo4j-client.cabal
+++ b/haskell-neo4j-client.cabal
@@ -37,7 +37,7 @@ Test-Suite test-haskell-neo4j-rest-client
      Type:           exitcode-stdio-1.0
      Hs-Source-Dirs: src, tests
      Main-is:        IntegrationTests.hs
-     Build-Depends:  base                        >= 4.6        && < 4.8
+     Build-Depends:  base                        >= 4.6        && < 4.9
                    , bytestring                  == 0.10.*
                    , test-framework              == 0.8.*
                    , test-framework-quickcheck2  == 0.3.*
@@ -72,7 +72,7 @@ library
                        Database.Neo4j.Property, Database.Neo4j.Label, Database.Neo4j.Index, Database.Neo4j.Batch.Node,
                        Database.Neo4j.Batch.Relationship, Database.Neo4j.Batch.Property,
                        Database.Neo4j.Batch.Label, Database.Neo4j.Batch.Types
-  build-depends:       base                  >= 4.6        && < 4.8
+  build-depends:       base                  >= 4.6        && < 4.9
                      , containers            == 0.5.*
                      , text                  >= 1.1        && < 1.3
                      , http-conduit          == 2.1.*

--- a/src/Database/Neo4j/Batch/Label.hs
+++ b/src/Database/Neo4j/Batch/Label.hs
@@ -38,7 +38,7 @@ getNodesByLabelAndProperty lbl prop = nextState cmd
           propUrl Nothing = ""
           propUrl (Just (name, value)) = '?' : urlEncodeVars [(T.unpack name, lbsToStr $ J.encode value)]
           lbsToStr = S.unpack . L.toStrict
-          parser jn g = foldl (\gacc n -> G.addNodeLabel n lbl (G.addNode n gacc)) g (tryParseBody jn)
+          parser jn g = foldl (\gacc n -> G.addNodeLabel n lbl (G.addNode n gacc)) g (tryParseBody jn :: [Node])
 
 -- | Add labels to a node
 -- | Raises Neo4jNoEntityException if the node doesn't exist
@@ -46,7 +46,7 @@ addLabels :: NodeBatchIdentifier a => [Label] -> a -> Batch (BatchFuture ())
 addLabels lbls n = nextState cmd
     where cmd = defCmd{cmdMethod = HT.methodPost, cmdPath = path, cmdBody = J.toJSON lbls, cmdParse = parser}
           path = getNodeBatchId n <> "/labels"
-          parser jn g = let from = parseLabelsPath jn "/labels" in foldl (flip (G.addNodeLabel from)) g lbls
+          parser jn g = let from = parseLabelsPath jn "/labels" in foldl (flip (G.addNodeLabel from)) g (lbls :: [Label])
 
 -- | Change node labels
 -- | Raises Neo4jNoEntityException if the node doesn't exist

--- a/src/Database/Neo4j/Batch/Relationship.hs
+++ b/src/Database/Neo4j/Batch/Relationship.hs
@@ -80,7 +80,7 @@ getRelationships :: NodeBatchIdentifier n => n -> Direction -> [RelationshipType
 getRelationships n dir types = nextState cmd
     where cmd = defCmd{cmdMethod = HT.methodGet, cmdPath = path, cmdBody = "", cmdParse = parser}
           path = getNodeBatchId n <> "/relationships/" <> dirStr dir <> filterStr types
-          parser jr g = foldl (flip G.addRelationship) g (tryParseBody jr)
+          parser jr g = foldl (flip G.addRelationship) g (tryParseBody jr :: [Relationship])
           dirStr Outgoing = "out"
           dirStr Incoming = "in"
           dirStr Any = "all"

--- a/src/Database/Neo4j/Traversal.hs
+++ b/src/Database/Neo4j/Traversal.hs
@@ -22,6 +22,8 @@ module Database.Neo4j.Traversal (
 
 import Data.Default
 
+import Prelude hiding (traverse)
+
 import Control.Applicative
 import Control.Exception.Base (throw, catch)
 import Control.Monad (mzero)

--- a/src/Database/Neo4j/Types.hs
+++ b/src/Database/Neo4j/Types.hs
@@ -340,7 +340,7 @@ instance Applicative Neo4j where
     (<*>) = ap
 
 instance MonadIO Neo4j where
-	liftIO f = Neo4j $ const (liftIO f)
+    liftIO f = Neo4j $ const (liftIO f)
 
 instance MonadThrow Neo4j where
     throwM e = Neo4j $ const (throw e)


### PR DESCRIPTION
 * Increase base upper bound to 4.9
 * foldl is now exported from Data.Foldable
   Added type annotations in order to help GHC know which Foldable instance is being used.
 * Hide traverse function from Prelude
 * Remove tab character in MonadIO instance