### PR TITLE
Fix compatibility with base >= 4.11.0.0

### DIFF
--- a/src/Database/Neo4j/Types.hs
+++ b/src/Database/Neo4j/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -41,8 +42,10 @@ import qualified Network.HTTP.Types as HT
 
 newtype Neo4jVersion = Neo4jVersion {runVersion :: Version}
 
+#if __GLASGOW_HASKELL__ < 841
 (<>) :: (Monoid a) => a -> a -> a
 (<>) = mappend
+#endif
 
 -- | Type for a single value of a Neo4j property
 data Val = IntVal Int64 | BoolVal Bool | TextVal T.Text | DoubleVal Double deriving (Show, Eq)

--- a/tests/IntegrationTests.hs
+++ b/tests/IntegrationTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE FlexibleInstances, TemplateHaskell #-}
 module Main where
@@ -33,8 +34,10 @@ import qualified Database.Neo4j.Graph as G
 import qualified Database.Neo4j.Transactional.Cypher as TC
 import qualified Database.Neo4j.Traversal as T
 
+#if __GLASGOW_HASKELL__ < 841
 (<>) :: Monoid a => a -> a -> a
 (<>) = mappend
+#endif
 
 -- Get the string of a exception raised by an action
 getException :: IO a -> IO (Maybe Neo4jException)


### PR DESCRIPTION
This is a fix for https://github.com/asilvestre/haskell-neo4j-rest-client/issues/32. I have tested with both `lts-11` and `lts-12` to make sure that the build succeeds both when the `ifdef` is triggered and when it isn't.

Some Travis builds which use old GHC fail due to broken dependencies, while newer ones fail because of some actual tests that do not pass, but that does not have anything in common with the patch.